### PR TITLE
Fix Marshalling for ruby 3

### DIFF
--- a/lib/storext/class_methods.rb
+++ b/lib/storext/class_methods.rb
@@ -81,7 +81,7 @@ module Storext
     end
 
     def _load(yml)
-      YAML.load(yml)
+      YAML.unsafe_load(yml)
     end
 
     private

--- a/storext.gemspec
+++ b/storext.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
   s.test_files = Dir["test/**/*"]
 
   s.add_dependency "virtus"
-  s.add_dependency "activerecord", [">= 4.0", "< 7.1"]
+  s.add_dependency "activerecord", [">= 4.0"]
 
   s.add_development_dependency "pg"
   s.add_development_dependency "rspec"


### PR DESCRIPTION
In more recent versions of ruby the behaviour of `YAML.load` has changed to use safe loading by default. This change restores the previous behaviour by changing it to unsafe load. I considered using `safe_load` with a list of permitted classes but I'm not sure what the exhaustive list of possible classes would be.